### PR TITLE
Native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "async-trait"
@@ -1637,6 +1637,7 @@ dependencies = [
 name = "wai-bindgen-gen-rust-wasm"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "heck",
  "structopt",
  "test-helpers",

--- a/crates/gen-rust-wasm/Cargo.toml
+++ b/crates/gen-rust-wasm/Cargo.toml
@@ -17,6 +17,7 @@ structopt = { version = "0.3", default-features = false, optional = true }
 [dev-dependencies]
 wai-bindgen-rust = { path = '../rust-wasm' }
 test-helpers = { path = '../test-helpers', features = ['wai-bindgen-gen-rust-wasm'] }
+anyhow = "1.0.45"
 
 [features]
 witx-compat = ['wai-bindgen-gen-core/witx-compat']

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -350,7 +350,7 @@ impl Generator for RustWasm {
                     }};
                     #[cfg(not(any(target_arch = \"wasm32\", target_arch = \"wasm64\")))]
                     const _: () = {{
-                        #[export_name = \"resource_drop_{name}\"]
+                        #[export_name = \"{ns}resource_drop_{name}\"]
                         extern \"C\" fn drop(ty: Box<super::{ty}>) {{
                             <super::{iface} as {iface}>::drop_{name_snake}(*ty)
                         }}

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -576,10 +576,16 @@ impl Generator for RustWasm {
         let is_dtor = self.types.is_preview1_dtor_func(func);
         let rust_name = func.name.to_snake_case();
 
-        self.src.push_str("#[export_name = \"");
+        self.src.push_str("#[cfg_attr(target_arch = \"wasm32\", export_name = \"");
         self.src.push_str(&self.opts.symbol_namespace);
         self.src.push_str(&func.name);
-        self.src.push_str("\"]\n");
+        self.src.push_str("\")]\n");
+        self.src.push_str("#[cfg_attr(not(target_arch = \"wasm32\"), export_name = \"");
+        self.src.push_str(&self.opts.symbol_namespace);
+        self.src.push_str(&iface.name);
+        self.src.push_str("_");
+        self.src.push_str(&func.name);
+        self.src.push_str("\")]\n");
         self.src.push_str("unsafe extern \"C\" fn __wai_bindgen_");
         self.src.push_str(&rust_name);
         self.src.push_str("(");

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -1247,8 +1247,11 @@ impl Bindgen for FunctionBindgen<'_> {
                 self.push_str(");\n");
                 self.push_str("}\n");
                 results.push(result);
+                // To keep the api implementation identical for native and wasm
+                // the api is still owned. But the caller deallocates the resources.
                 self.push_str(&format!(
-                    "std::alloc::dealloc(
+                    "#[cfg(target_arch = \"wasm32\")]
+                    std::alloc::dealloc(
                         {} as *mut _,
                         std::alloc::Layout::from_size_align_unchecked(
                             ({} as usize) * {},

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -598,8 +598,10 @@ impl Generator for RustWasm {
             self.src.push_str(", ");
             params.push(name);
         }
-        self.src
-            .push_str("#[cfg(not(target_arch = \"wasm32\"))] ret: *mut i64");
+        if self.i64_return_pointer_area_size > 0 {
+            self.src
+                .push_str("#[cfg(not(target_arch = \"wasm32\"))] ret: *mut i64");
+        }
         self.src.push_str(")");
 
         match sig.results.len() {

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -573,11 +573,13 @@ impl Generator for RustWasm {
         let is_dtor = self.types.is_preview1_dtor_func(func);
         let rust_name = func.name.to_snake_case();
 
-        self.src.push_str("#[cfg_attr(target_arch = \"wasm32\", export_name = \"");
+        self.src
+            .push_str("#[cfg_attr(target_arch = \"wasm32\", export_name = \"");
         self.src.push_str(&self.opts.symbol_namespace);
         self.src.push_str(&func.name);
         self.src.push_str("\")]\n");
-        self.src.push_str("#[cfg_attr(not(target_arch = \"wasm32\"), export_name = \"");
+        self.src
+            .push_str("#[cfg_attr(not(target_arch = \"wasm32\"), export_name = \"");
         self.src.push_str(&self.opts.symbol_namespace);
         self.src.push_str(&iface.name);
         self.src.push_str("_");
@@ -596,7 +598,8 @@ impl Generator for RustWasm {
             self.src.push_str(", ");
             params.push(name);
         }
-        self.src.push_str("#[cfg(not(target_arch = \"wasm32\"))] ret: *mut i64");
+        self.src
+            .push_str("#[cfg(not(target_arch = \"wasm32\"))] ret: *mut i64");
         self.src.push_str(")");
 
         match sig.results.len() {
@@ -897,7 +900,10 @@ impl Bindgen for FunctionBindgen<'_> {
         self.push_str(&format!("let ptr{} = RET_AREA.as_mut_ptr() as i32;\n", tmp));
         if self.gen.in_import {
             self.push_str("#[cfg(not(target_arch = \"wasm32\"))]");
-            self.push_str(&format!("let ptr{} = &mut [0i64; {}] as *mut i64 as i32;\n", tmp, amt));
+            self.push_str(&format!(
+                "let ptr{} = &mut [0i64; {}] as *mut i64 as i32;\n",
+                tmp, amt
+            ));
         } else {
             self.push_str("#[cfg(not(target_arch = \"wasm32\"))]");
             self.push_str(&format!("let ptr{} = ret as i32;\n", tmp));

--- a/crates/gen-rust-wasm/src/lib.rs
+++ b/crates/gen-rust-wasm/src/lib.rs
@@ -295,7 +295,7 @@ impl Generator for RustWasm {
             ";
             self.src.push_str(&format!(
                 "
-                    unsafe impl wai_bindgen_rust::HandleType for super::{ty} {{
+                    unsafe impl wai_bindgen_rust::handle::HandleType for super::{ty} {{
                         #[inline]
                         fn clone(_val: i32) -> i32 {{
                             {panic_not_wasm}
@@ -323,7 +323,7 @@ impl Generator for RustWasm {
                         }}
                     }}
 
-                    unsafe impl wai_bindgen_rust::LocalHandle for super::{ty} {{
+                    unsafe impl wai_bindgen_rust::handle::LocalHandle for super::{ty} {{
                         #[inline]
                         fn new(_val: i32) -> i32 {{
                             {panic_not_wasm}

--- a/crates/gen-rust-wasm/tests/runtime.rs
+++ b/crates/gen-rust-wasm/tests/runtime.rs
@@ -1,0 +1,1 @@
+test_helpers::runtime_tests_native!();

--- a/crates/rust-wasm/src/futures.rs
+++ b/crates/rust-wasm/src/futures.rs
@@ -8,13 +8,13 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::task::*;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 #[link(wasm_import_module = "canonical_abi")]
 extern "C" {
     pub fn async_export_done(ctx: i32, ptr: i32);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 pub unsafe extern "C" fn async_export_done(_ctx: i32, _ptr: i32) {
     panic!("only supported on wasm");
 }

--- a/crates/rust-wasm/src/handle/native.rs
+++ b/crates/rust-wasm/src/handle/native.rs
@@ -1,0 +1,77 @@
+use std::ops::Deref;
+use std::{fmt, marker, mem};
+
+/// A type for handles to resources that appear in exported functions.
+///
+/// This type is used as `Handle<T>` for argument types and return values of
+/// exported functions when exposing a Rust-defined resource. A `Handle<T>`
+/// represents an owned reference count on the interface-types-managed resource.
+/// It's similar to an `Rc<T>` in Rust. Internally a `Handle<T>` can provide
+/// access to `&T` when `T` is defined in the current module.
+pub struct Handle<T> {
+    val: i32,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<T> Handle<T> {
+    /// Creates a new handle around the specified value.
+    ///
+    /// Note that the lifetime of `T` will afterwards be managed by the
+    /// interface types runtime. The host may hold references to `T` that wasm
+    /// isn't necessarily aware of, preventing its destruction. Nevertheless
+    /// though the `Drop for T` implementation will still be run when there are
+    /// no more references to `T`.
+    pub fn new(val: T) -> Handle<T> {
+        unsafe { Handle::from_raw(Box::into_raw(Box::new(val)) as i32) }
+    }
+
+    /// Consumes a handle and returns the underlying raw wasm i32 descriptor.
+    ///
+    /// Note that this, if used improperly, will leak the resource `T`. This
+    /// generally should be avoided unless you're calling raw ABI bindings and
+    /// managing the lifetime manually.
+    pub fn into_raw(handle: Handle<T>) -> i32 {
+        let ret = handle.val;
+        mem::forget(handle);
+        ret
+    }
+
+    /// Returns the raw underlying handle value for this handle.
+    ///
+    /// This typically isn't necessary to interact with, but can be useful when
+    /// interacting with raw ABI bindings.
+    pub fn as_raw(handle: &Handle<T>) -> i32 {
+        handle.val
+    }
+
+    /// Unsafely assumes that the given integer descriptor is a handle for `T`.
+    ///
+    /// This is unsafe because no validation is performed to ensure that `val`
+    /// is actually a valid descriptor for `T`.
+    pub unsafe fn from_raw(val: i32) -> Handle<T> {
+        Handle {
+            val,
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl<T> Deref for Handle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*(self.val as *const T) }
+    }
+}
+
+impl<T> From<T> for Handle<T> {
+    fn from(val: T) -> Handle<T> {
+        Handle::new(val)
+    }
+}
+
+impl<T> fmt::Debug for Handle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handle").field("val", &self.val).finish()
+    }
+}

--- a/crates/rust-wasm/src/handle/wasm.rs
+++ b/crates/rust-wasm/src/handle/wasm.rs
@@ -1,0 +1,113 @@
+use std::ops::Deref;
+use std::{fmt, marker, mem};
+
+/// A type for handles to resources that appear in exported functions.
+///
+/// This type is used as `Handle<T>` for argument types and return values of
+/// exported functions when exposing a Rust-defined resource. A `Handle<T>`
+/// represents an owned reference count on the interface-types-managed resource.
+/// It's similar to an `Rc<T>` in Rust. Internally a `Handle<T>` can provide
+/// access to `&T` when `T` is defined in the current module.
+pub struct Handle<T: HandleType> {
+    val: i32,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<T: HandleType> Handle<T> {
+    /// Creates a new handle around the specified value.
+    ///
+    /// Note that the lifetime of `T` will afterwards be managed by the
+    /// interface types runtime. The host may hold references to `T` that wasm
+    /// isn't necessarily aware of, preventing its destruction. Nevertheless
+    /// though the `Drop for T` implementation will still be run when there are
+    /// no more references to `T`.
+    pub fn new(val: T) -> Handle<T>
+    where
+        T: LocalHandle,
+    {
+        unsafe { Handle::from_raw(T::new(Box::into_raw(Box::new(val)) as i32)) }
+    }
+
+    /// Consumes a handle and returns the underlying raw wasm i32 descriptor.
+    ///
+    /// Note that this, if used improperly, will leak the resource `T`. This
+    /// generally should be avoided unless you're calling raw ABI bindings and
+    /// managing the lifetime manually.
+    pub fn into_raw(handle: Handle<T>) -> i32 {
+        let ret = handle.val;
+        mem::forget(handle);
+        ret
+    }
+
+    /// Returns the raw underlying handle value for this handle.
+    ///
+    /// This typically isn't necessary to interact with, but can be useful when
+    /// interacting with raw ABI bindings.
+    pub fn as_raw(handle: &Handle<T>) -> i32 {
+        handle.val
+    }
+
+    /// Unsafely assumes that the given integer descriptor is a handle for `T`.
+    ///
+    /// This is unsafe because no validation is performed to ensure that `val`
+    /// is actually a valid descriptor for `T`.
+    pub unsafe fn from_raw(val: i32) -> Handle<T> {
+        Handle {
+            val,
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl<T: LocalHandle> Deref for Handle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*(T::get(self.val) as *const T) }
+    }
+}
+
+impl<T: LocalHandle> From<T> for Handle<T> {
+    fn from(val: T) -> Handle<T> {
+        Handle::new(val)
+    }
+}
+
+impl<T: HandleType> Clone for Handle<T> {
+    fn clone(&self) -> Self {
+        unsafe { Handle::from_raw(T::clone(self.val)) }
+    }
+}
+
+impl<T: HandleType> fmt::Debug for Handle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handle").field("val", &self.val).finish()
+    }
+}
+
+impl<T: HandleType> Drop for Handle<T> {
+    fn drop(&mut self) {
+        T::drop(self.val);
+    }
+}
+
+/// A trait for types that can show up as the `T` in `Handle<T>`.
+///
+/// This trait is automatically synthesized for exported handles and typically
+/// shouldn't be implemented manually.
+pub unsafe trait HandleType {
+    #[doc(hidden)]
+    fn clone(val: i32) -> i32;
+    #[doc(hidden)]
+    fn drop(val: i32);
+}
+
+/// An extension of the [`HandleType`] trait for locally-defined types.
+///
+/// This trait may not stick around forever...
+pub unsafe trait LocalHandle: HandleType {
+    #[doc(hidden)]
+    fn new(val: i32) -> i32;
+    #[doc(hidden)]
+    fn get(val: i32) -> i32;
+}

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -1,124 +1,19 @@
 pub use async_trait::async_trait;
-use std::fmt;
-use std::marker;
-use std::mem;
-use std::ops::Deref;
 pub use wai_bindgen_rust_impl::{export, import};
 
 pub mod exports;
 mod futures;
 pub mod imports;
 
-/// A type for handles to resources that appear in exported functions.
-///
-/// This type is used as `Handle<T>` for argument types and return values of
-/// exported functions when exposing a Rust-defined resource. A `Handle<T>`
-/// represents an owned reference count on the interface-types-managed resource.
-/// It's similar to an `Rc<T>` in Rust. Internally a `Handle<T>` can provide
-/// access to `&T` when `T` is defined in the current module.
-pub struct Handle<T: HandleType> {
-    val: i32,
-    _marker: marker::PhantomData<T>,
-}
+#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+#[path = "handle/wasm.rs"]
+pub mod handle;
 
-impl<T: HandleType> Handle<T> {
-    /// Creates a new handle around the specified value.
-    ///
-    /// Note that the lifetime of `T` will afterwards be managed by the
-    /// interface types runtime. The host may hold references to `T` that wasm
-    /// isn't necessarily aware of, preventing its destruction. Nevertheless
-    /// though the `Drop for T` implementation will still be run when there are
-    /// no more references to `T`.
-    pub fn new(val: T) -> Handle<T>
-    where
-        T: LocalHandle,
-    {
-        unsafe { Handle::from_raw(T::new(Box::into_raw(Box::new(val)) as i32)) }
-    }
+#[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+#[path = "handle/native.rs"]
+pub mod handle;
 
-    /// Consumes a handle and returns the underlying raw wasm i32 descriptor.
-    ///
-    /// Note that this, if used improperly, will leak the resource `T`. This
-    /// generally should be avoided unless you're calling raw ABI bindings and
-    /// managing the lifetime manually.
-    pub fn into_raw(handle: Handle<T>) -> i32 {
-        let ret = handle.val;
-        mem::forget(handle);
-        ret
-    }
-
-    /// Returns the raw underlying handle value for this handle.
-    ///
-    /// This typically isn't necessary to interact with, but can be useful when
-    /// interacting with raw ABI bindings.
-    pub fn as_raw(handle: &Handle<T>) -> i32 {
-        handle.val
-    }
-
-    /// Unsafely assumes that the given integer descriptor is a handle for `T`.
-    ///
-    /// This is unsafe because no validation is performed to ensure that `val`
-    /// is actually a valid descriptor for `T`.
-    pub unsafe fn from_raw(val: i32) -> Handle<T> {
-        Handle {
-            val,
-            _marker: marker::PhantomData,
-        }
-    }
-}
-
-impl<T: LocalHandle> Deref for Handle<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*(T::get(self.val) as *const T) }
-    }
-}
-
-impl<T: LocalHandle> From<T> for Handle<T> {
-    fn from(val: T) -> Handle<T> {
-        Handle::new(val)
-    }
-}
-
-impl<T: HandleType> Clone for Handle<T> {
-    fn clone(&self) -> Self {
-        unsafe { Handle::from_raw(T::clone(self.val)) }
-    }
-}
-
-impl<T: HandleType> fmt::Debug for Handle<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Handle").field("val", &self.val).finish()
-    }
-}
-
-impl<T: HandleType> Drop for Handle<T> {
-    fn drop(&mut self) {
-        T::drop(self.val);
-    }
-}
-
-/// A trait for types that can show up as the `T` in `Handle<T>`.
-///
-/// This trait is automatically synthesized for exported handles and typically
-/// shouldn't be implemented manually.
-pub unsafe trait HandleType {
-    #[doc(hidden)]
-    fn clone(val: i32) -> i32;
-    #[doc(hidden)]
-    fn drop(val: i32);
-}
-
-/// An extension of the [`HandleType`] trait for locally-defined types.
-///
-/// This trait may not stick around forever...
-pub unsafe trait LocalHandle: HandleType {
-    #[doc(hidden)]
-    fn new(val: i32) -> i32;
-    #[doc(hidden)]
-    fn get(val: i32) -> i32;
-}
+pub use handle::Handle;
 
 #[doc(hidden)]
 pub mod rt {

--- a/crates/rust-wasm/src/lib.rs
+++ b/crates/rust-wasm/src/lib.rs
@@ -5,11 +5,11 @@ pub mod exports;
 mod futures;
 pub mod imports;
 
-#[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+#[cfg(target_family = "wasm")]
 #[path = "handle/wasm.rs"]
 pub mod handle;
 
-#[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+#[cfg(not(target_family = "wasm"))]
 #[path = "handle/native.rs"]
 pub mod handle;
 

--- a/tests/runtime/smoke/native.rs
+++ b/tests/runtime/smoke/native.rs
@@ -1,0 +1,18 @@
+use anyhow::Result;
+
+wai_bindgen_rust::export!("./tests/runtime/smoke/imports.wai");
+
+struct Imports;
+
+impl imports::Imports for Imports {
+    fn thunk() {
+        println!("in the host");
+    }
+}
+
+wai_bindgen_rust::import!("./tests/runtime/smoke/exports.wai");
+
+fn run() -> Result<()> {
+    exports::thunk();
+    Ok(())
+}

--- a/tests/runtime/smoke/wasm.rs
+++ b/tests/runtime/smoke/wasm.rs
@@ -5,6 +5,7 @@ struct Exports;
 
 impl exports::Exports for Exports {
     fn thunk() {
+        println!("in the wasm");
         imports::thunk();
     }
 }


### PR DESCRIPTION
Adds not too hacky support for generating non wasm interfaces as explained in #99 

This will only work on 32bit architectures at the moment, but can be tested on `i686-unknown-linux-gnu`. The push/pull buffers and async functions are not implemented yet and left for future work.

Here is the test setup: https://github.com/dvc94ch/wai-native